### PR TITLE
fix: update web- component dependency to 2.0.1

### DIFF
--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
@@ -30,8 +30,8 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumb")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.0")
-@JsModule("@vaadin-component-factory/vcf-breadcrumb/vcf-breadcrumbs.js")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.1")
+@JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumb extends LitTemplate {
 
   /**

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
@@ -33,8 +33,8 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumbs")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.0")
-@JsModule("@vaadin-component-factory/vcf-breadcrumb/vcf-breadcrumbs.js")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.1")
+@JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, HasSize {
 
   /**


### PR DESCRIPTION
This new version fix problems with exports and java integration and removes no needed class "hidden" on anchors.