### PR TITLE
Update web-component version to 2.1.0

### DIFF
--- a/breadcrumb-demo/pom.xml
+++ b/breadcrumb-demo/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>breadcrumb-demo</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <name>Breadcrumb Demo</name>
 

--- a/breadcrumb/pom.xml
+++ b/breadcrumb/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>breadcrumb</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <name>Breadcrumb Component</name>
 

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumb")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.0")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumb extends LitTemplate {
 

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumbs")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.0")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, HasSize {
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>breadcrumb-root</artifactId>
 	<packaging>pom</packaging>
-	<version>3.0.2-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<name>Breadcrumb Root</name>
 


### PR DESCRIPTION
This PR includes an update to use new web-component version [2.1.0](https://github.com/vaadin-component-factory/vcf-breadcrumb/releases/tag/v2.1.0) which includes:

- New feature to display a popover showing the hidden breadcrumbs items on ellipsis element 
- A fix to the resizing logic to avoid weird flickering 

As the new web-component version contains a feature, the version of this component is updated to 3.1.0-SNAPSHOT.