### PR TITLE
Update web-component version to 2.1.1

### DIFF
--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumb")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.1")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumb extends LitTemplate {
 

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumbs")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.1")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, HasSize {
 


### PR DESCRIPTION
This [new web-component version](https://github.com/vaadin-component-factory/vcf-breadcrumb/releases/tag/v2.1.1) contains fix to show focus ring without clipping. 