### PR TITLE
Add support for mobile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Breadcrumbs "Components" && "VCF Components" will collapse and show ellipsis whe
     - Each range is hidden when necessary and replaced with an ellipsis element.
 - `shift` attribute from previous version was removed. Responsive behavior is now given by the `collapse` attribute implementation.
 
+## Updates since version 3.1.0
+
+- Update web component version to [2.1.0](https://github.com/vaadin-component-factory/vcf-breadcrumb/releases/tag/v2.1.0). This version includes new feature to display a popover showing the hidden (collapsible) breadcrumbs items on ellipsis element when space is not enough to display all breadcrumbs.
+
+## Updates since version 3.2.0
+
+- Update web component version to [2.2.0](https://github.com/vaadin-component-factory/vcf-breadcrumb/releases/tag/v2.2.0). This version adds support for [Mobile Mode](https://github.com/vaadin-component-factory/vcf-breadcrumb/issues/6), which can be triggered in two ways:
+	- Based on a fixed breakpoint (same as other Vaadin components): `(max-width: 450px), (max-height: 450px)` or
+	- Programmatically, using the flag `forceMobileMode`, which allows to enable mobile layout manually
+
+![breadcrumbs-mobile-mode](https://github.com/user-attachments/assets/1c555264-944a-4134-83d2-6b47e0c32610)
+
 ## Setting up for development:
 Clone the project in GitHub (or fork it if you plan on contributing)
 ```

--- a/breadcrumb-demo/pom.xml
+++ b/breadcrumb-demo/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>breadcrumb-demo</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <name>Breadcrumb Demo</name>
 

--- a/breadcrumb-demo/src/main/java/com/vaadin/componentfactory/demo/BreadcrumbView.java
+++ b/breadcrumb-demo/src/main/java/com/vaadin/componentfactory/demo/BreadcrumbView.java
@@ -21,6 +21,7 @@ public class BreadcrumbView extends DemoView {
     collapseExample();
     collapseEllispisOnlyExample();
     stylingExample();
+    forcingMobileModeExample();
   }
 
   private void basicUseExample() {
@@ -50,7 +51,7 @@ public class BreadcrumbView extends DemoView {
         new Breadcrumb("Components", "breadcrumbs/#", true),
         new Breadcrumb("VCF Components", "breadcrumbs/#", true), 
         new Breadcrumb("Breadcrumbs"));
-    breadcrumbs.setWidth("350px");
+    breadcrumbs.setMaxWidth("460px");
     Div description = new Div();
     description.setText("The first item in the breadcrumb is always shown in full. "
         + "The items with 'collapse' in true are clipped and shown with ellipsis when space runs out.");
@@ -60,16 +61,19 @@ public class BreadcrumbView extends DemoView {
   private void collapseEllispisOnlyExample() {
     Breadcrumbs breadcrumbs = new Breadcrumbs(
         new Breadcrumb("Home", "breadcrumbs/#"),
-        new Breadcrumb("Vaadin Flow", "breadcrumbs/#", true),
+        new Breadcrumb("Add-ons Directory", "breadcrumbs/#", true),
+        new Breadcrumb("Flow", "breadcrumbs/#", true),
+        new Breadcrumb("Vaadin Latest ", "breadcrumbs/#", true),
         new Breadcrumb("Components", "breadcrumbs/#"),
+        new Breadcrumb("Sponsored", "breadcrumbs/#", true),
         new Breadcrumb("VCF Components", "breadcrumbs/#", true), 
         new Breadcrumb("Breadcrumbs"));
-    breadcrumbs.setWidth("250px");
+    breadcrumbs.setMaxWidth("460px");
     Div description = new Div();
     description.setText(
         "If space is limited, the items with 'collapse' in true are hidden and a single ellipsis element is shown instead."
             + " The first item is always shown in full.");
-    addCard("Breadcrumbs showing collapse elements replaced with ellipsis element.", breadcrumbs,
+    addCard("Breadcrumbs showing collapse elements replaced with ellipsis element", breadcrumbs,
         description);
   }
 
@@ -85,6 +89,16 @@ public class BreadcrumbView extends DemoView {
         + " change default color of anchor links and make \"Home\" to have a different color "
         + "than the rest of the breadcrumbs.");
     addCard("Breadcrumbs with styling", breadcrumbs, description);
+  }
+  
+  private void forcingMobileModeExample() {
+    Breadcrumbs breadcrumbs = new Breadcrumbs(
+        new Breadcrumb("Home", "breadcrumbs/#"),
+        new Breadcrumb("Components", "breadcrumbs/#"),
+        new Breadcrumb("VCF Components", "breadcrumbs/#"), 
+        new Breadcrumb("Breadcrumbs"));
+    breadcrumbs.setForceMobileMode(true);
+    addCard("Mobile mode forced by flag", breadcrumbs);
   }
 
   private Breadcrumb createStyledBreadcrumb(String text, String href) {

--- a/breadcrumb/pom.xml
+++ b/breadcrumb/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>breadcrumb</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <name>Breadcrumb Component</name>
 

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumb.java
@@ -30,7 +30,7 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  * @author Vaadin Ltd
  */
 @Tag("vcf-breadcrumb")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.2.0")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumb extends LitTemplate {
 

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
@@ -46,5 +46,27 @@ public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, Ha
   public Breadcrumbs(Breadcrumb... breadcrumbs) {
     add(breadcrumbs);
   }
+
+  /**
+   * Sets whether the component should force mobile mode, regardless of the current screen size or
+   * media query state.
+   * <p>
+   * This allows programmatic control over mobile styling, for example when the application uses its
+   * own logic to detect mobile devices.
+   *
+   * @param forceMobileMode {@code true} to enable mobile mode manually; {@code false} to disable it
+   */
+  public void setForceMobileMode(boolean forceMobileMode) {
+    getElement().setProperty("forceMobileMode", forceMobileMode);
+  }
+
+  /**
+   * Returns whether mobile mode has been forced programmatically.
+   *
+   * @return {@code true} if mobile mode is enabled, {@code false} otherwise
+   */
+  public boolean isForceMobileMode() {
+    return getElement().getProperty("forceMobileMode", false);
+  }
   
 }

--- a/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
+++ b/breadcrumb/src/main/java/com/vaadin/componentfactory/Breadcrumbs.java
@@ -32,8 +32,9 @@ import com.vaadin.flow.component.littemplate.LitTemplate;
  *
  * @author Vaadin Ltd
  */
+@SuppressWarnings("serial")
 @Tag("vcf-breadcrumbs")
-@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.1.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-breadcrumb", version = "2.2.0")
 @JsModule("@vaadin-component-factory/vcf-breadcrumb/dist/src/vcf-breadcrumbs.js")
 public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, HasSize {
 
@@ -45,4 +46,5 @@ public class Breadcrumbs extends LitTemplate implements HasOrderedComponents, Ha
   public Breadcrumbs(Breadcrumb... breadcrumbs) {
     add(breadcrumbs);
   }
+  
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>breadcrumb-root</artifactId>
 	<packaging>pom</packaging>
-	<version>3.1.2-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 
 	<name>Breadcrumb Root</name>
 


### PR DESCRIPTION
This PR includes update to use new web-component version [2.2.0](https://github.com/vaadin-component-factory/vcf-breadcrumb/releases/tag/v2.2.0) which includes support for mobile mode. The PR also includes a minor API update to allow setting the mobile suport programtically from server side and a demo update on how to use this new feature.

